### PR TITLE
fix: windows separator issue

### DIFF
--- a/src/utils/resolve.js
+++ b/src/utils/resolve.js
@@ -26,7 +26,7 @@ class PathResolve {
     try {
       await fs.accessSync(directoryPath, fs.constants.F_OK);
     } catch (err) {
-      if (directoryPath[directoryPath.length - 1] === "/") {
+      if (directoryPath[directoryPath.length - 1] === path.sep) {
         await fs.mkdirSync(directoryPath, { recursive: true });
       }
     }


### PR DESCRIPTION
changed "/" comparator to path.sep, because linux use / and windows use \ and path.sep resolve this